### PR TITLE
Fix reveal icon toggling

### DIFF
--- a/lib/widgets/code_pegs.dart
+++ b/lib/widgets/code_pegs.dart
@@ -28,15 +28,17 @@ class _CodePegsState extends State<CodePegs> {
             appState.reveal ? Circle(color: secret[1]) : peg,
             appState.reveal ? Circle(color: secret[2]) : peg,
             appState.reveal ? Circle(color: secret[3]) : peg,
-            ClipOval(
-              child: Container(
-                child: IconButton(
-                  color: Colors.white54,
-                  onPressed: appState.revealCode,
-                  icon: Icon(FontAwesomeIcons.eyeSlash),
+              ClipOval(
+                child: Container(
+                  child: IconButton(
+                    color: Colors.white54,
+                    onPressed: appState.revealCode,
+                    icon: Icon(appState.reveal
+                        ? FontAwesomeIcons.eyeSlash
+                        : FontAwesomeIcons.eye),
+                  ),
                 ),
-              ),
-            )
+              )
           ],
         );
       },


### PR DESCRIPTION
## Summary
- update reveal button icon in `CodePegs` widget to reflect hidden/revealed state

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f0fd8458832f98bad37d8cd89860